### PR TITLE
Update manifest.json

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -6,8 +6,8 @@
 	"name": "presonus-studiolive",
 	"version": "0.0.0",
 	"license": "MIT",
-	"repository": "git+https://github.com/bitfocus/companion-module-your-module-name.git",
-	"bugs": "https://github.com/bitfocus/companion-module-your-module-name/issues",
+	"repository": "git+https://github.com/featherbear/bitfocus-companion-module-presonus-studiolive.git",
+	"bugs": "https://github.com/featherbear/bitfocus-companion-module-presonus-studiolive/issues",
 	"maintainers": [
 		{
 			"name": "Andrew Wong",


### PR DESCRIPTION
Companion 3.x now requires valid links in manifest.json (checked with Companion 3.2.1). 
```
Instance/Modules: Looking for extra modules in: /opt/companion-module-dev
Instance/Modules: Error loading module from "/opt/companion-module-dev/companion-module-presonus-studiolive": Error: Manifest incorrectly references template module 'companion-module-your-module-name'
Instance/Modules: Found 0 extra modules
```
This PR links current repository of this module.